### PR TITLE
chore: update docs

### DIFF
--- a/documentation/src/03-guides-example.md
+++ b/documentation/src/03-guides-example.md
@@ -13,7 +13,7 @@ import { HttpJsonRpcConnector, LotusClient } from 'filecoin.js';
 
 (async () => {
 
-  const connector = new HttpJsonRpcConnector({ url: __LOTUS_RPC_ENDPOINT__, token: __LOTUS_AUTH_TOKEN__ });
+  const httpConnector = new HttpJsonRpcConnector({ url: __LOTUS_HTTP_RPC_ENDPOINT__, token: __LOTUS_AUTH_TOKEN__ });
 
   const lotusClient = new LotusClient(httpConnector);
   const version = await lotusClient.common.version();
@@ -29,7 +29,7 @@ Browser:
 <script type="text/javascript">
 (async () => {
 
-  const connector = new FilecoinJs.HttpJsonRpcConnector({ url: __LOTUS_RPC_ENDPOINT__, token: __LOTUS_AUTH_TOKEN__ });
+  const httpConnector = new FilecoinJs.HttpJsonRpcConnector({ url: __LOTUS_HTTP_RPC_ENDPOINT__, token: __LOTUS_AUTH_TOKEN__ });
 
   const lotusClient = new FilecoinJs.LotusClient(httpConnector);
   const version = await lotusClient.common.version();

--- a/documentation/src/08-setup-mnemonic-provider.md
+++ b/documentation/src/08-setup-mnemonic-provider.md
@@ -23,7 +23,7 @@ import { HttpJsonRpcConnector, MnemonicWalletProvider } from 'filecoin.js';
     hdDerivationPath
   );
 
-  const myAddress = await walletProvider.getDefaultAccount();
+  const myAddress = await walletProvider.getDefaultAddress();
   console.log(myAddress);
   // f1zx43cf6qb6rd...
 
@@ -48,7 +48,7 @@ Browser:
     hdDerivationPath
   );
 
-  const myAddress = await walletProvider.getDefaultAccount();
+  const myAddress = await walletProvider.getDefaultAddress();
   console.log(myAddress);
   // f1zx43cf6qb6rd...
 

--- a/documentation/src/09-setup-metamask-provider.md
+++ b/documentation/src/09-setup-metamask-provider.md
@@ -27,8 +27,9 @@ To simplify the actual snap install we built a helper which does the work for yo
 
     const metamaskWalletProvider = new FilecoinJs.MetamaskWalletProvider(lotusClient, metamaskHelper.filecoinApi)
 
+    let metamaskAddress
     try {
-        metamaskAddress = await metamaskWalletProvider.getDefaultAccount();
+        metamaskAddress = await metamaskWalletProvider.getDefaultAddress();
     } catch (e) {
         console.log('metamask error',e);
     }


### PR DESCRIPTION
I went through the docs website and noticed some inconsistencies and outdated information. In addition, the [deployed docs website](https://filecoin-shipyard.github.io/filecoin.js/) does not seem updated with the repo content. More specifically, I found in the Setup example that `LotusWalletProvider` should be the new `HttpJsonRpcWalletProvider` and `getDefaultAccount` should be `getDefaultAddress`.