### PR TITLE
Upgrade rpc-websockets dependency to address critical vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,16 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "101": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/101/-/101-1.6.3.tgz",
-      "integrity": "sha512-4dmQ45yY0Dx24Qxp+zAsNLlMF6tteCyfVzgbulvSyC7tCyd3V8sW76sS0tHq8NpcbXfWTKasfyfzU1Kd86oKzw==",
-      "requires": {
-        "clone": "^1.0.2",
-        "deep-eql": "^0.1.3",
-        "keypather": "^1.10.2"
-      }
-    },
     "@babel/code-frame": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
@@ -41,9 +31,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.1.tgz",
-      "integrity": "sha512-J5AIf3vPj3UwXaAzb5j1xM4WAQDX3EMgemF8rjCP3SoW09LfRKAXQKt6CoVYl230P6iWdRcBbnLDDdnqWxZSCA==",
+      "version": "7.17.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.2.tgz",
+      "integrity": "sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==",
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -1460,19 +1450,6 @@
         }
       }
     },
-    "assert-args": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/assert-args/-/assert-args-1.2.1.tgz",
-      "integrity": "sha1-QEEDoUUqMv53iYgR5U5ZCoqTc70=",
-      "requires": {
-        "101": "^1.2.0",
-        "compound-subject": "0.0.1",
-        "debug": "^2.2.0",
-        "get-prototype-of": "0.0.0",
-        "is-capitalized": "^1.0.0",
-        "is-class": "0.0.4"
-      }
-    },
     "assign-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
@@ -1495,7 +1472,8 @@
     "async-limiter": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
-      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
+      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
+      "dev": true
     },
     "asynckit": {
       "version": "0.4.0",
@@ -1521,22 +1499,6 @@
       "integrity": "sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==",
       "requires": {
         "follow-redirects": "^1.10.0"
-      }
-    },
-    "babel-runtime": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-      "requires": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
-      },
-      "dependencies": {
-        "regenerator-runtime": {
-          "version": "0.11.1",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
-        }
       }
     },
     "backo2": {
@@ -2461,11 +2423,6 @@
         }
       }
     },
-    "clone": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
-    },
     "collection-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
@@ -2544,11 +2501,6 @@
       "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
       "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM=",
       "dev": true
-    },
-    "compound-subject": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/compound-subject/-/compound-subject-0.0.1.tgz",
-      "integrity": "sha1-JxVUaYoVrmCLHfyv0wt7oeqJLEs="
     },
     "compressible": {
       "version": "2.0.18",
@@ -2799,11 +2751,6 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
     },
-    "core-js": {
-      "version": "2.6.11",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-      "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
-    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -2964,14 +2911,6 @@
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
-    },
-    "deep-eql": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
-      "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
-      "requires": {
-        "type-detect": "0.1.1"
-      }
     },
     "deep-extend": {
       "version": "0.6.0",
@@ -3899,9 +3838,9 @@
       "dev": true
     },
     "eventemitter3": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
-      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
     },
     "events": {
       "version": "3.2.0",
@@ -4743,11 +4682,6 @@
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
     },
-    "get-prototype-of": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/get-prototype-of/-/get-prototype-of-0.0.0.tgz",
-      "integrity": "sha1-mHcr0QcW0W3rSzIlFsRp78oorEQ="
-    },
     "get-stdin": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
@@ -5498,20 +5432,10 @@
       "integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==",
       "dev": true
     },
-    "is-capitalized": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-capitalized/-/is-capitalized-1.0.0.tgz",
-      "integrity": "sha1-TIRktNkdPk7rRIid0s2PGwrEwTY="
-    },
     "is-circular": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-circular/-/is-circular-1.0.2.tgz",
       "integrity": "sha512-YttjnrswnUYRVJvxCvu8z+PGMUSzC2JttP0OEXezlAEdp3EXzhf7IZ3j0gRAybJBQupedIZFhY61Tga6E0qASA=="
-    },
-    "is-class": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/is-class/-/is-class-0.0.4.tgz",
-      "integrity": "sha1-4FdFFwW7NOOePjNZjJOpg3KWtzY="
     },
     "is-data-descriptor": {
       "version": "0.1.4",
@@ -5880,14 +5804,6 @@
       "dev": true,
       "requires": {
         "minimist": "^1.2.3"
-      }
-    },
-    "keypather": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/keypather/-/keypather-1.10.2.tgz",
-      "integrity": "sha1-4ESWMtSz5RbyHMAUznxWRP3c5hQ=",
-      "requires": {
-        "101": "^1.0.0"
       }
     },
     "kind-of": {
@@ -11503,9 +11419,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.7",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+      "version": "0.13.9",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
     },
     "regex-not": {
       "version": "1.0.2",
@@ -11682,26 +11598,23 @@
       }
     },
     "rpc-websockets": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-5.3.1.tgz",
-      "integrity": "sha512-rIxEl1BbXRlIA9ON7EmY/2GUM7RLMy8zrUPTiLPFiYnYOz0I3PXfCmDDrge5vt4pW4oIcAXBDvgZuJ1jlY5+VA==",
+      "version": "7.4.17",
+      "resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-7.4.17.tgz",
+      "integrity": "sha512-eolVi/qlXS13viIUH9aqrde902wzSLAai0IjmOZSRefp5I3CSG/vCnD0c0fDSYCWuEyUoRL1BHQA8K1baEUyow==",
       "requires": {
-        "@babel/runtime": "^7.8.7",
-        "assert-args": "^1.2.1",
-        "babel-runtime": "^6.26.0",
+        "@babel/runtime": "^7.11.2",
+        "bufferutil": "^4.0.1",
         "circular-json": "^0.5.9",
-        "eventemitter3": "^3.1.2",
-        "uuid": "^3.4.0",
-        "ws": "^5.2.2"
+        "eventemitter3": "^4.0.7",
+        "utf-8-validate": "^5.0.2",
+        "uuid": "^8.3.0",
+        "ws": "^7.4.5"
       },
       "dependencies": {
         "ws": {
-          "version": "5.2.2",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
-          "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
-          "requires": {
-            "async-limiter": "~1.0.0"
-          }
+          "version": "7.5.7",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.7.tgz",
+          "integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A=="
         }
       }
     },
@@ -13490,11 +13403,6 @@
         "prelude-ls": "^1.2.1"
       }
     },
-    "type-detect": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
-      "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI="
-    },
     "type-fest": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
@@ -13781,9 +13689,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "v8-compile-cache": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "events": "^3.2.0",
     "isomorphic-ws": "^4.0.1",
     "node-fetch": "^2.6.0",
-    "rpc-websockets": "^5.3.1",
+    "rpc-websockets": "^7.4.17",
     "scrypt-async": "^2.0.1",
     "tweetnacl": "^1.0.3",
     "tweetnacl-util": "^0.15.1",


### PR DESCRIPTION
The current version of rpc-websockets causes a "Prototype pollution in 101" critical vulnerability when running `yarn audit`. This PR updates the dependency to fix this issue. We are using `filecoin.js` inside of Truffle, making the rpc-websockets package a transitive dependency for us. 

Please let me know if I can help in any way to get this change merged and published. Thanks!