### PR TITLE
Bump package to 0.0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # filecoin.js
 
+## Publishing this package
+
+Before publishing you will probably need to perform an `npm run build` and `npm run bundle`, otherwise the package will get published without its built files.
+
 ## Status
 
 This repository is in a **standby** state. It is not being actively maintained or kept in sync with the libraries it depends on. It may be archived in the near future. If you are interested in updating or maintaining this library, please open an issue or pull request for discussion.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@trufflesuite/filecoin.js",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "filecoin.js",
-  "version": "0.0.3-alpha",
+  "name": "@trufflesuite/filecoin.js",
+  "version": "0.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trufflesuite/filecoin.js",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "A JavaScript/TypeScript client library for Filecoin.io's Lotus",
   "main": "builds/dist/index.js",
   "types": "builds/dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trufflesuite/filecoin.js",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "A JavaScript/TypeScript client library for Filecoin.io's Lotus",
   "main": "builds/dist/index.js",
   "types": "builds/dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@truffle/filecoin.js",
+  "name": "@trufflesuite/filecoin.js",
   "version": "0.0.1",
   "description": "A JavaScript/TypeScript client library for Filecoin.io's Lotus",
   "main": "builds/dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "filecoin.js",
-  "version": "0.0.3-alpha",
+  "name": "@truffle/filecoin.js",
+  "version": "0.0.1",
   "description": "A JavaScript/TypeScript client library for Filecoin.io's Lotus",
   "main": "builds/dist/index.js",
   "types": "builds/dist/index.d.ts",


### PR DESCRIPTION
Add note to the readme that you will probably need to build before publishing as the last version was published without the built files and is therefore useless.